### PR TITLE
Update utils.py - enable start-end date

### DIFF
--- a/quantstats/utils.py
+++ b/quantstats/utils.py
@@ -236,6 +236,10 @@ def _prepare_returns(data, rf=0.0, nperiods=None):
 
 
 def download_returns(ticker, period="max", proxy=None):
+    """
+    Period parse in as yfinance format "max" or 
+    as pd.DatetimeIndex([...]) array.
+    """
     params = {
         "tickers": ticker,
         "proxy": proxy,
@@ -245,6 +249,8 @@ def download_returns(ticker, period="max", proxy=None):
     }
     if isinstance(period, _pd.DatetimeIndex):
         params["start"] = period[0]
+        if len(period) > 1:
+            params["end"] = period[-1]
     else:
         params["period"] = period
     df = _yf.download(**params)["Close"].pct_change()


### PR DESCRIPTION
allow download_returns() to take in Start_date and End_date as pd.DatetimeIndex array.
<img width="788" alt="Screenshot 2024-11-21 at 18 42 58" src="https://github.com/user-attachments/assets/00821e0f-dd0e-48be-b2cd-3ac2a81e6578">
